### PR TITLE
Remove LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,19 +1,10 @@
-*.mp4 filter=lfs diff=lfs merge=lfs -text
-*.webm filter=lfs diff=lfs merge=lfs -text
-*.gif filter=lfs diff=lfs merge=lfs -text
-*.png filter=lfs diff=lfs merge=lfs -text
-*.jpg filter=lfs diff=lfs merge=lfs -text
-*.usd filter=lfs diff=lfs merge=lfs -text
-*.usda filter=lfs diff=lfs merge=lfs -text
-*.usdz filter=lfs diff=lfs merge=lfs -text
-*.usdc filter=lfs diff=lfs merge=lfs -text
-*.jt filter=lfs diff=lfs merge=lfs -text
-*.stp filter=lfs diff=lfs merge=lfs -text
-*.step filter=lfs diff=lfs merge=lfs -text
-*.fbx filter=lfs diff=lfs merge=lfs -text
-*.obj filter=lfs diff=lfs merge=lfs -text
-*.dae filter=lfs diff=lfs merge=lfs -text
-*.iges filter=lfs diff=lfs merge=lfs -text
-*.igs filter=lfs diff=lfs merge=lfs -text
-*.x_t filter=lfs diff=lfs merge=lfs -text
-*.3dm filter=lfs diff=lfs merge=lfs -text
+# Normalize text files on commit to LF endings by default
+* text=auto
+# Make sure Windows batch files preserve CR/LF line endings, otherwise they may not be able to execute.  Windows
+# batch files require a CR/LF for labels to work properly, otherwise they may fail when labels straddle 512-byte
+# block boundaries.  This is important when files are downloaded through a zip archive that was authored on a
+# Linux machine (the default behavior on GitHub)
+*.bat text eol=crlf
+*.cmd text eol=crlf
+# Make sure shell scripts have LF line endings, even when checked out on a Windows client with autocrlf=true
+*.sh text eol=lf


### PR DESCRIPTION
You can't push LFS objects to forks without an enterprise support so I'm ditching LFS. We'll just need to be mindful of file sizes that we upload.